### PR TITLE
Rename protected methods to retain pre-2020 backwards compat

### DIFF
--- a/gen/Command.yml
+++ b/gen/Command.yml
@@ -53,21 +53,38 @@ classes:
       GetSubsystem:
       SetSubsystem:
       InitSendable:
+      # protected methods: rename for backwards compat
       SetTimeout:
+        rename: setTimeout
       IsTimedOut:
+        rename: isTimedOut
       AssertUnlocked:
+        rename: assertUnlocked
       SetParent:
+        rename: setParent
         keepalive:
         - [1, 2]
       IsParented:
+        rename: isParented
       ClearRequirements:
+        rename: clearRequirements
       Initialize:
+        rename: initialize
       Execute:
+        rename: execute
       IsFinished:
+        rename: isFinished
       End:
+        rename: end
       Interrupted:
+        rename: interrupted
       _Initialize:
+        rename: _initialize
       _Interrupted:
+        rename: _interrupted
       _Execute:
+        rename: _execute
       _End:
+        rename: _end
       _Cancel:
+        rename: _cancel

--- a/gen/CommandGroup.yml
+++ b/gen/CommandGroup.yml
@@ -31,11 +31,20 @@ classes:
       IsInterruptible:
       GetSize:
       Initialize:
+        rename: initialize
       Execute:
+        rename: execute
       IsFinished:
+        rename: isFinished
       End:
+        rename: end
       Interrupted:
+        rename: interrupted
       _Initialize:
+        rename: _initialize
       _Execute:
+        rename: _execute
       _End:
+        rename: _end
       _Interrupted:
+        rename: _interrupted

--- a/gen/ConditionalCommand.yml
+++ b/gen/ConditionalCommand.yml
@@ -21,6 +21,10 @@ classes:
             - [1, 4]
       Condition:
       _Initialize:
+        rename: _initialize
       _Cancel:
+        rename: _cancel
       IsFinished:
+        rename: isFinished
       _Interrupted:
+        rename: _interrupted

--- a/gen/InstantCommand.yml
+++ b/gen/InstantCommand.yml
@@ -29,4 +29,6 @@ classes:
           "":
       function<void:
       _Initialize:
+        rename: _initialize
       IsFinished:
+        rename: isFinished

--- a/gen/PIDCommand.yml
+++ b/gen/PIDCommand.yml
@@ -41,11 +41,20 @@ classes:
       PIDGet:
       InitSendable:
       GetPIDController:
+        rename: getPIDController
       _Initialize:
+        rename: _initialize
       _Interrupted:
+        rename: _interrupted
       _End:
+        rename: _end
       SetSetpoint:
+        rename: setSetpoint
       GetSetpoint:
+        rename: getSetpoint
       GetPosition:
+        rename: getPosition
       ReturnPIDInput:
+        rename: returnPIDInput
       UsePIDOutput:
+        rename: usePIDOutput

--- a/gen/PIDSubsystem.yml
+++ b/gen/PIDSubsystem.yml
@@ -33,5 +33,8 @@ classes:
       SetPercentTolerance:
       OnTarget:
       GetPIDController:
+        rename: getPIDController
       ReturnPIDInput:
+        rename: returnPIDInput
       UsePIDOutput:
+        rename: usePIDOutput

--- a/gen/PrintCommand.yml
+++ b/gen/PrintCommand.yml
@@ -11,3 +11,4 @@ classes:
     methods:
       PrintCommand:
       Initialize:
+        rename: initialize

--- a/gen/StartCommand.yml
+++ b/gen/StartCommand.yml
@@ -13,3 +13,4 @@ classes:
         keepalive:
         - [1, 2]
       Initialize:
+        rename: initialize

--- a/gen/TimedCommand.yml
+++ b/gen/TimedCommand.yml
@@ -20,3 +20,4 @@ classes:
             keepalive:
              - [1, 3]
       IsFinished:
+        rename: isFinished

--- a/gen/WaitForChildren.yml
+++ b/gen/WaitForChildren.yml
@@ -14,3 +14,4 @@ classes:
           double:
           wpi::Twine&, double:
       IsFinished:
+        rename: isFinished

--- a/gen/WaitUntilCommand.yml
+++ b/gen/WaitUntilCommand.yml
@@ -14,3 +14,4 @@ classes:
           double:
           wpi::Twine&, double:
       IsFinished:
+        rename: isFinished


### PR DESCRIPTION
.. ironically a breaking change for 2020 which I don't usually do in the middle of the season, but long term this is better?

@picode98 and @benjiboy50fonz do you have opinions on this? The effect would be most of the command stuff would be back as it was previously, instead of protected methods starting with underscores.

@auscompgeek may also have sage advice.