### PR TITLE
Remove keepalive on Trigger.initSendable

### DIFF
--- a/gen/Trigger.yml
+++ b/gen/Trigger.yml
@@ -31,5 +31,3 @@ classes:
         keepalive:
         - [1, 2]
       InitSendable:
-        keepalive:
-        - [1, 2]


### PR DESCRIPTION
Presumably this was inadvertently added.