### PR TITLE
Prevents Commands from being garbage collected

### DIFF
--- a/gen/Button.yml
+++ b/gen/Button.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   Button:
     shared_ptr: true
+    nodelete: true
     methods:
       Button:
       WhenPressed:

--- a/gen/Command.yml
+++ b/gen/Command.yml
@@ -7,6 +7,7 @@ extra_includes:
 classes:
   Command:
     shared_ptr: true
+    nodelete: true
     ignored_bases:
     - SendableHelper<Command>
     methods:

--- a/gen/CommandGroup.yml
+++ b/gen/CommandGroup.yml
@@ -7,6 +7,7 @@ extra_includes:
 classes:
   CommandGroup:
     shared_ptr: true
+    nodelete: true
     methods:
       CommandGroup:
         overloads:

--- a/gen/ConditionalCommand.yml
+++ b/gen/ConditionalCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   ConditionalCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       ConditionalCommand:
         overloads:

--- a/gen/InstantCommand.yml
+++ b/gen/InstantCommand.yml
@@ -29,6 +29,7 @@ classes:
             - [1, 2]
           "":
       function<void:
+        ignore: true
       _Initialize:
         rename: _initialize
       IsFinished:

--- a/gen/InstantCommand.yml
+++ b/gen/InstantCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   InstantCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       InstantCommand:
         overloads:

--- a/gen/InternalButton.yml
+++ b/gen/InternalButton.yml
@@ -9,6 +9,7 @@ extra_includes:
 classes:
   InternalButton:
     shared_ptr: true
+    nodelete: true
     methods:
       InternalButton:
         overloads:

--- a/gen/JoystickButton.yml
+++ b/gen/JoystickButton.yml
@@ -9,6 +9,7 @@ extra_includes:
 classes:
   JoystickButton:
     shared_ptr: true
+    nodelete: true
     methods:
       JoystickButton:
         keepalive:

--- a/gen/NetworkButton.yml
+++ b/gen/NetworkButton.yml
@@ -9,6 +9,7 @@ extra_includes:
 classes:
   NetworkButton:
     shared_ptr: true
+    nodelete: true
     methods:
       NetworkButton:
         overloads:

--- a/gen/PIDCommand.yml
+++ b/gen/PIDCommand.yml
@@ -9,6 +9,7 @@ extra_includes:
 classes:
   PIDCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       PIDCommand:
         overloads:

--- a/gen/POVButton.yml
+++ b/gen/POVButton.yml
@@ -9,6 +9,7 @@ extra_includes:
 classes:
   POVButton:
     shared_ptr: true
+    nodelete: true
     methods:
       POVButton:
         keepalive:

--- a/gen/PrintCommand.yml
+++ b/gen/PrintCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   PrintCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       PrintCommand:
       Initialize:

--- a/gen/TimedCommand.yml
+++ b/gen/TimedCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   TimedCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       TimedCommand:
         overloads:

--- a/gen/WaitCommand.yml
+++ b/gen/WaitCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   WaitCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       WaitCommand:
         overloads:

--- a/gen/WaitForChildren.yml
+++ b/gen/WaitForChildren.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   WaitForChildren:
     shared_ptr: true
+    nodelete: true
     methods:
       WaitForChildren:
         overloads:

--- a/gen/WaitUntilCommand.yml
+++ b/gen/WaitUntilCommand.yml
@@ -8,6 +8,7 @@ extra_includes:
 classes:
   WaitUntilCommand:
     shared_ptr: true
+    nodelete: true
     methods:
       WaitUntilCommand:
         overloads:


### PR DESCRIPTION
I don't know if this will be helpful for #5 or not. If I understand nodelete, this wouldn't cause memory leaks for my team, and I imagine most other teams would be similar. I don't know of any sane paradigm that requires multiplying single-use commands. (If nodelete allows manual deletion with del, even that could be managed.) If this is totally wrong or not the direction you want to go, feel free to decline.